### PR TITLE
Fixed OD flaky test tk.mybatis.mapper.test.country.TestDeleteByPrimaryKey.testDynamicDeleteEntity

### DIFF
--- a/base/src/test/java/tk/mybatis/mapper/test/country/TestDeleteByPrimaryKey.java
+++ b/base/src/test/java/tk/mybatis/mapper/test/country/TestDeleteByPrimaryKey.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import tk.mybatis.mapper.mapper.CountryMapper;
 import tk.mybatis.mapper.mapper.MybatisHelper;
 import tk.mybatis.mapper.model.Country;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.sql.Connection;
@@ -45,8 +46,9 @@ import java.util.Map;
  * @author liuzh
  */
 public class TestDeleteByPrimaryKey {
-	@Before
-	public void setupDB() {
+
+    @Before
+    public void setupDB() {
         SqlSession sqlSession = MybatisHelper.getSqlSession();
         try {
             Connection conn = sqlSession.getConnection();
@@ -55,11 +57,11 @@ public class TestDeleteByPrimaryKey {
             runner.setLogWriter(null);
             runner.runScript(reader);
             reader.close();
-        } catch (IOException e) {} 
+        } catch (IOException e) {}
         finally {
             sqlSession.close();
         }
-	}
+    }
 	
     /**
      * 主要测试删除

--- a/base/src/test/java/tk/mybatis/mapper/test/country/TestDeleteByPrimaryKey.java
+++ b/base/src/test/java/tk/mybatis/mapper/test/country/TestDeleteByPrimaryKey.java
@@ -24,13 +24,18 @@
 
 package tk.mybatis.mapper.test.country;
 
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import tk.mybatis.mapper.mapper.CountryMapper;
 import tk.mybatis.mapper.mapper.MybatisHelper;
 import tk.mybatis.mapper.model.Country;
-
+import java.io.IOException;
+import java.io.Reader;
+import java.sql.Connection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,7 +45,22 @@ import java.util.Map;
  * @author liuzh
  */
 public class TestDeleteByPrimaryKey {
-
+	@Before
+	public void setupDB() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            Connection conn = sqlSession.getConnection();
+            Reader reader = Resources.getResourceAsReader("CreateDB.sql");
+            ScriptRunner runner = new ScriptRunner(conn);
+            runner.setLogWriter(null);
+            runner.runScript(reader);
+            reader.close();
+        } catch (IOException e) {} 
+        finally {
+            sqlSession.close();
+        }
+	}
+	
     /**
      * 主要测试删除
      */


### PR DESCRIPTION
The OD test fails when the two polluters detected by iDFlakies and iFixFlakies are run before the dependent test.
```json
"dependentTest": "tk.mybatis.mapper.test.country.TestDeleteByPrimaryKey.testDynamicDeleteEntity",
"polluters": [
    "tk.mybatis.mapper.test.ids.TestIds.testSelectByIds",
    "tk.mybatis.mapper.base.genid.InsertGenIdTest.testGenId"
]
```
And with the patch suggested by iFixFlakies, if we call the `init()` method before the victim test, the test passes no matter in which order we run it.